### PR TITLE
Include name of the module being processed, when composer install fails.

### DIFF
--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -32,15 +32,15 @@ class ModuleInstaller extends LibraryInstaller
 
         $name = $package->getPrettyName();
         if (!preg_match('@^.*/simplesamlphp-module-(.+)$@', $name, $matches)) {
-            throw new \InvalidArgumentException('Unable to install module, package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME".');
+            throw new \InvalidArgumentException('Unable to install module ' . $name .', package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME".');
         }
         $moduleDir = $matches[1];
 
         if (!preg_match('@^[a-z0-9_.-]*$@', $moduleDir)) {
-            throw new \InvalidArgumentException('Unable to install module, module name must only contain characters from a-z, 0-9, "_", "." and "-".');
+            throw new \InvalidArgumentException('Unable to install module ' . $name .', module name must only contain characters from a-z, 0-9, "_", "." and "-".');
         }
         if ($moduleDir[0] === '.') {
-            throw new \InvalidArgumentException('Unable to install module, module name cannot start with ".".');
+            throw new \InvalidArgumentException('Unable to install module ' . $name .', module name cannot start with ".".');
         }
 
         /* Composer packages are supposed to only contain lowercase letters, but historically many modules have had names in mixed case.
@@ -50,10 +50,10 @@ class ModuleInstaller extends LibraryInstaller
         if (isset($extraData['ssp-mixedcase-module-name'])) {
             $mixedCaseModuleName = $extraData['ssp-mixedcase-module-name'];
             if (!is_string($mixedCaseModuleName)) {
-                throw new \InvalidArgumentException('Unable to install module, "ssp-mixedcase-module-name" must be a string.');
+                throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must be a string.');
             }
             if (mb_strtolower($mixedCaseModuleName, 'utf-8') !== $moduleDir) {
-                throw new \InvalidArgumentException('Unable to install module, "ssp-mixedcase-module-name" must match the package name except that it can contain uppercase letters.');
+                throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must match the package name except that it can contain uppercase letters.');
             }
             $moduleDir = $mixedCaseModuleName;
         }


### PR DESCRIPTION
Just a small usability improvement to make it easier to identify which module is being rejected due to nonconforming module name convention.