### PR TITLE
Detect if mbstring is installed.

### DIFF
--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -52,6 +52,9 @@ class ModuleInstaller extends LibraryInstaller
             if (!is_string($mixedCaseModuleName)) {
                 throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must be a string.');
             }
+            if (!extension_loaded('mbstring')) {
+                throw new \InvalidArgumentException('mbstring extension is required for mixed cased modules.');
+            }
             if (mb_strtolower($mixedCaseModuleName, 'utf-8') !== $moduleDir) {
                 throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must match the package name except that it can contain uppercase letters.');
             }


### PR DESCRIPTION
Otherwise mb_strtolower is a noop and the next if block fails.

Maybe there is a better way to handle the extension not being installed, but at least erroring with a tip will save people time debugging installation issues.