### PR TITLE
Update README.md syntax fixes in json examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ something like:
     "description": "A description of the module 'mymodule'.",
     "type": "simplesamlphp-module",
     "require": {
-        "simplesamlphp/composer-module-installer": "~1.0",
+        "simplesamlphp/composer-module-installer": "~1.0"
     }
 }
 ```
@@ -115,7 +115,7 @@ name can be provided in the `ssp-mixedcase-module-name` extra data option:
         "ssp-mixedcase-module-name": "myModule"
     },
     "require": {
-        "simplesamlphp/composer-module-installer": "~1.1",
+        "simplesamlphp/composer-module-installer": "~1.1"
     }
 }
 ```


### PR DESCRIPTION
just two little fixes in the json examples. Eliminate trailing commas.