### PR TITLE
Added SimpleSAMLphp as a dependency because it must be installed before

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "class": "SimpleSamlPhp\\Composer\\ModuleInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0",
+        "simplesamlphp/simplesamlphp": "*"
     }
 }


### PR DESCRIPTION
The modules must be installed in the right place when SimpleSAMLphp is [used via composer](https://github.com/simplesamlphp/composer-module-installer/blob/master/src/SimpleSamlPhp/Composer/ModuleInstaller.php#L25-L31). So, SimpleSAMLphp must be installed first.

Added SimpleSAMLphp as a requirement to ensure that it is installed first.