### PR TITLE
Prevent installation of modules in wrong directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "class": "SimpleSamlPhp\\Composer\\ModuleInstallerPlugin"
     },
     "require": {
-        "php": "^7.0",
         "composer-plugin-api": "^1.0",
         "simplesamlphp/simplesamlphp": "*"
     }

--- a/src/SimpleSamlPhp/Composer/MissingSimpleSamlException.php
+++ b/src/SimpleSamlPhp/Composer/MissingSimpleSamlException.php
@@ -1,0 +1,6 @@
+<?php
+namespace SimpleSamlPhp\Composer;
+
+class MissingSimpleSamlException extends \InvalidArgumentException
+{
+}

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -16,6 +16,7 @@ class ModuleInstaller extends LibraryInstaller
         try {
             return parent::isInstalled($repo, $package);
         } catch (MissingSimpleSamlException $e) {
+            // if simplesamlphp isn't installed we can sure that this module also isn't installed
             return false;
         }
     }

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -3,9 +3,19 @@ namespace SimpleSamlPhp\Composer;
 
 use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller;
+use Composer\Repository\InstalledRepositoryInterface;
 
 class ModuleInstaller extends LibraryInstaller
 {
+    public function isInstalled(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        try {
+            return parent::isInstalled($repo, $package);
+        } catch (MissingSimpleSamlException $e) {
+            return false;
+        }
+    }
+
 
     /**
      * {@inheritDoc}
@@ -31,7 +41,7 @@ class ModuleInstaller extends LibraryInstaller
                 ->findPackage('simplesamlphp/simplesamlphp', '*');
 
             if ($ssp_pack === null) {
-                throw new \InvalidArgumentException('Unable to install module ' . $name .'. Couldn\'t find install path of simplesamlphp/simplesamlphp.');
+                throw new MissingSimpleSamlException('Unable to install module ' . $name .'. Couldn\'t find install path of simplesamlphp/simplesamlphp.');
             }
 
             $ssp_path = $this->composer->getInstallationManager()->getInstallPath($ssp_pack);

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -85,7 +85,7 @@ class ModuleInstaller extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function supports(string $packageType)
+    public function supports($packageType)
     {
         return 'simplesamlphp-module' === $packageType;
     }

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -21,6 +21,7 @@ class ModuleInstaller extends LibraryInstaller
      */
     protected function getPackageBasePath(PackageInterface $package)
     {
+        $name = $package->getPrettyName();
         if ($this->composer->getPackage()->getName() === 'simplesamlphp/simplesamlphp') {
             $ssp_path = '.';
         } else {
@@ -36,7 +37,6 @@ class ModuleInstaller extends LibraryInstaller
             $ssp_path = $this->composer->getInstallationManager()->getInstallPath($ssp_pack);
         }
 
-        $name = $package->getPrettyName();
         if (!preg_match('@^.*/simplesamlphp-module-(.+)$@', $name, $matches)) {
             throw new \InvalidArgumentException('Unable to install module ' . $name .', package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME".');
         }

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -21,12 +21,18 @@ class ModuleInstaller extends LibraryInstaller
      */
     protected function getPackageBasePath(PackageInterface $package)
     {
-        $ssp_path = '.';
-        $ssp_pack = $this->composer
-            ->getRepositoryManager()
-            ->getLocalRepository()
-            ->findPackage('simplesamlphp/simplesamlphp', '*');
-        if ($ssp_pack !== null) {
+        if ($this->composer->getPackage()->getName() === 'simplesamlphp/simplesamlphp') {
+            $ssp_path = '.';
+        } else {
+            $ssp_pack = $this->composer
+                ->getRepositoryManager()
+                ->getLocalRepository()
+                ->findPackage('simplesamlphp/simplesamlphp', '*');
+
+            if ($ssp_pack === null) {
+                throw new \InvalidArgumentException('Unable to install module ' . $name .'. Couldn\'t find install path of simplesamlphp/simplesamlphp.');
+            }
+
             $ssp_path = $this->composer->getInstallationManager()->getInstallPath($ssp_pack);
         }
 


### PR DESCRIPTION
At the moment it is possible that the composer modules was installed into the wrong directory. See #3 

With this fix it shouldn't be possible to install modules into the wrong modules directory and both ways to install simplesamlphp are still supported.

~~The drawback of this change is that all simplesamlphp modules have to require simplesamlphp to ensure the correct installation order by composer but I think this is the correct way because the modules just doesn't make sense without simplesaml.~~ This problem exists already. It isn't required but should be prevered.