### PR TITLE
Add information about licence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "simplesamlphp/composer-module-installer",
     "description": "A Composer plugin that allows installing SimpleSAMLphp modules through Composer.",
+    "license": "LGPL-2.1-only",
     "type": "composer-plugin",
     "autoload": {
         "psr-0": {"SimpleSamlPhp\\Composer": "src/"}


### PR DESCRIPTION
It's important to expose used licence in your `composer.json`. Packagist or a license checker will fail without it.