### PR TITLE
Fix for composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "LGPL-2.1-only",
     "type": "composer-plugin",
     "autoload": {
-        "psr-0": {"SimpleSamlPhp\\Composer": "src/"}
+        "psr-0": {"SimpleSAML\\Composer": "src/"}
     },
     "extra": {
-        "class": "SimpleSamlPhp\\Composer\\ModuleInstallerPlugin"
+        "class": "SimpleSAML\\Composer\\ModuleInstallerPlugin"
     },
     "require": {
         "composer-plugin-api": "^1.1|^2.0",

--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -1,9 +1,14 @@
 <?php
 
-namespace SimpleSamlPhp\Composer;
+namespace SimpleSAML\Composer;
 
+use InvalidArgumentException;
 use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller;
+
+use function is_string;
+use function mb_strtolower;
+use function preg_match;
 
 class ModuleInstaller extends LibraryInstaller
 {
@@ -32,15 +37,15 @@ class ModuleInstaller extends LibraryInstaller
 
         $name = $package->getPrettyName();
         if (!preg_match('@^.*/simplesamlphp-module-(.+)$@', $name, $matches)) {
-            throw new \InvalidArgumentException('Unable to install module ' . $name .', package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME".');
+            throw new InvalidArgumentException('Unable to install module ' . $name .', package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME".');
         }
         $moduleDir = $matches[1];
 
         if (!preg_match('@^[a-z0-9_.-]*$@', $moduleDir)) {
-            throw new \InvalidArgumentException('Unable to install module ' . $name .', module name must only contain characters from a-z, 0-9, "_", "." and "-".');
+            throw new InvalidArgumentException('Unable to install module ' . $name .', module name must only contain characters from a-z, 0-9, "_", "." and "-".');
         }
         if ($moduleDir[0] === '.') {
-            throw new \InvalidArgumentException('Unable to install module ' . $name .', module name cannot start with ".".');
+            throw new InvalidArgumentException('Unable to install module ' . $name .', module name cannot start with ".".');
         }
 
         /* Composer packages are supposed to only contain lowercase letters, but historically many modules have had names in mixed case.
@@ -50,10 +55,10 @@ class ModuleInstaller extends LibraryInstaller
         if (isset($extraData['ssp-mixedcase-module-name'])) {
             $mixedCaseModuleName = $extraData['ssp-mixedcase-module-name'];
             if (!is_string($mixedCaseModuleName)) {
-                throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must be a string.');
+                throw new InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must be a string.');
             }
             if (mb_strtolower($mixedCaseModuleName, 'utf-8') !== $moduleDir) {
-                throw new \InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must match the package name except that it can contain uppercase letters.');
+                throw new InvalidArgumentException('Unable to install module ' . $name .', "ssp-mixedcase-module-name" must match the package name except that it can contain uppercase letters.');
             }
             $moduleDir = $mixedCaseModuleName;
         }

--- a/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
@@ -5,6 +5,10 @@ namespace SimpleSamlPhp\Composer;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
+use React\Promise\PromiseInterface;
+
+use function file_exists;
+use function sprintf;
 
 class ModuleInstallerPlugin implements PluginInterface
 {
@@ -47,6 +51,16 @@ class ModuleInstallerPlugin implements PluginInterface
      */
     public function uninstall(Composer $composer, IOInterface $io)
     {
-        // Not implemented
+        $installPath = $this->getPackageBasePath($package);
+
+        $io = $this->io;
+        $outputStatus = function () use ($io, $installPath) {
+            $io->write(
+                sprintf('Deleting %s - %s', $installPath, !file_exists($installPath) ? '<comment>deleted</comment>' : '<error>not deleted</error>')
+            );
+        };
+
+        // If not, execute the code right away as parent::uninstall executed synchronously (composer v1, or v2 without async)
+        $outputStatus();
     }
 }

--- a/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
@@ -5,7 +5,6 @@ namespace SimpleSamlPhp\Composer;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use React\Promise\PromiseInterface;
 
 use function file_exists;
 use function sprintf;

--- a/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
@@ -11,6 +11,12 @@ use function sprintf;
 
 class ModuleInstallerPlugin implements PluginInterface
 {
+    /** @var \SimpleSamlPhp\Composer\ModuleInstaller */
+    private ModuleInstaller $installer;
+
+    /** @var \Composer\IO\IOInterface */
+    private IOInterface $io;
+
     /**
      * Apply plugin modifications to Composer
      *
@@ -19,8 +25,9 @@ class ModuleInstallerPlugin implements PluginInterface
      */
     public function activate(Composer $composer, IOInterface $io)
     {
-        $installer = new ModuleInstaller($io, $composer);
-        $composer->getInstallationManager()->addInstaller($installer);
+        $this->io = $io;
+        $this->installer = new ModuleInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($this->installer);
     }
 
 
@@ -50,7 +57,7 @@ class ModuleInstallerPlugin implements PluginInterface
      */
     public function uninstall(Composer $composer, IOInterface $io)
     {
-        $installPath = $this->getPackageBasePath($package);
+        $installPath = $this->installer->getPackageBasePath($package);
 
         $io = $this->io;
         $outputStatus = function () use ($io, $installPath) {

--- a/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstallerPlugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SimpleSamlPhp\Composer;
+namespace SimpleSAML\Composer;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
@@ -11,7 +11,7 @@ use function sprintf;
 
 class ModuleInstallerPlugin implements PluginInterface
 {
-    /** @var \SimpleSamlPhp\Composer\ModuleInstaller */
+    /** @var \SimpleSAML\Composer\ModuleInstaller */
     private ModuleInstaller $installer;
 
     /** @var \Composer\IO\IOInterface */


### PR DESCRIPTION
Some modules would not install correctly when using composer v2;

```

    Failed to extract simplesamlphp/simplesamlphp-module-metarefresh: (9) '/bin/unzip' -qq '/apps/development/tmp/vendor/composer/tmp-4a890bf1bef066d88be5107b9ecc71b7' -d '/apps/development/tmp/vendor/composer/c0902a0e'

unzip:  cannot find or open /apps/development/tmp/vendor/composer/tmp-4a890bf1bef066d88be5107b9ecc71b7.

    This most likely is due to a custom installer plugin not handling the returned Promise from the downloader
    See https://github.com/composer/installers/commit/5006d0c28730ade233a8f42ec31ac68fb1c5c9bb for an example fix

```