### PR TITLE
bugfix: return proper getPackageBasePath if simplesamlphp is not already installed

### DIFF
--- a/src/SimpleSamlPhp/Composer/ModuleInstaller.php
+++ b/src/SimpleSamlPhp/Composer/ModuleInstaller.php
@@ -21,13 +21,10 @@ class ModuleInstaller extends LibraryInstaller
      */
     protected function getPackageBasePath(PackageInterface $package)
     {
-        $ssp_path = '.';
-        $ssp_pack = $this->composer
-            ->getRepositoryManager()
-            ->getLocalRepository()
-            ->findPackage('simplesamlphp/simplesamlphp', '*');
-        if ($ssp_pack !== null) {
-            $ssp_path = $this->composer->getInstallationManager()->getInstallPath($ssp_pack);
+        if($this->composer->getPackage()->getPrettyName() === 'simplesamlphp/simplesamlphp') {
+            $ssp_path = ".";
+        } else {
+            $ssp_path = $this->composer->getConfig()->get('vendor-dir').'/simplesamlphp/simplesamlphp';
         }
 
         $name = $package->getPrettyName();


### PR DESCRIPTION
As many others https://github.com/simplesamlphp/composer-module-installer/issues/3, https://github.com/simplesamlphp/composer-module-installer/issues/10, https://github.com/simplesamlphp/composer-module-installer/pull/11 I also struggle with this. Since - IMHO - it not a problem of dependency resulution but **dependency installation order** I have created a [simple workaround](https://github.com/simplesamlphp/composer-module-installer/compare/master...derflocki:fix-find-module-path).

In https://github.com/simplesamlphp/composer-module-installer/pull/11 you wrote that:
> I also verified that removing SimpleSAMLphp itself as a dependency gets rid of the problem, and then that gets installed first, and all modules land correctly in the modules directory.
This does not seem to be true anymore, at least not with composer 2.2.13. I still end up with a `modules` folder.

The current code only works if `simplesamlphp/simplesamlphp` is already installed. Since we have no control about the installation order, this might fail, without a warning.
My proposed solution is not super clean - and very similar to https://github.com/simplesamlphp/composer-module-installer/pull/11 but does not rely on simplesamlphp alreay beeing on the disk.

